### PR TITLE
Add <xsl:strip-space> element to remove whitespace

### DIFF
--- a/m3u.xsl
+++ b/m3u.xsl
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:strip-space  elements="*"/>
 <xsl:output method="text" indent="yes" encoding="UTF-8" omit-xml-declaration="yes"/>
     <xsl:template match="rss/channel">
         <text>


### PR DESCRIPTION
Removes whitespace at begining of the M3U files which ensures MPD reads EXT information correctly (for titles).